### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/flickr_scraper.py
+++ b/flickr_scraper.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 
 from flickrapi import FlickrAPI
-
 from utils.general import download_uri
 
 key = ""  # Flickr API key https://www.flickr.com/services/apps/create/apply

--- a/flickr_scraper.py
+++ b/flickr_scraper.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 from flickrapi import FlickrAPI
+
 from utils.general import download_uri
 
 key = ""  # Flickr API key https://www.flickr.com/services/apps/create/apply


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor updates to improve code organization and formatting consistency in the repository. ✨  

### 📊 Key Changes  
- Added minor adjustments to the GitHub Actions workflow for improved readability. 🛠️  
- Cleaned up code in `flickr_scraper.py` by removing an unnecessary blank line. 🧹  

### 🎯 Purpose & Impact  
- Enhances code structure and adherence to formatting standards, making it more professional and easier to maintain. 📏  
- Simplifies the reading experience for developers working on or reviewing the repository. 👩‍💻