### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in CI from `actions/checkout@v4` to `actions/checkout@v6` to keep the automation workflow current and supported.

### 📊 Key Changes
- Upgraded the **GitHub Actions checkout action** in `.github/workflows/ci.yml`
- Changed:
  - `actions/checkout@v4` → `actions/checkout@v6`
- No application code, scraper logic, or user-facing features were changed

### 🎯 Purpose & Impact
- ✅ **Keeps CI up to date** with the latest supported GitHub Actions version
- 🔒 **Improves maintenance and compatibility** by reducing reliance on older workflow dependencies
- ⚙️ **Helps ensure reliable automated testing and workflow execution** going forward
- 👥 **Minimal impact for end users** since this is an internal infrastructure update, but it supports a healthier development pipeline