### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ key = "YOUR_API_KEY"
 secret = "YOUR_API_SECRET"
 ```
 
-3.  **Execute the Script**: Run the script from your terminal, specifying your search query, the number of images to fetch (`--n`), and the `--download` flag to save them locally. Downloaded images are saved by default to the `flickr_scraper/images/` directory, organized into subfolders based on the search query.
+3.  **Execute the Script**: Run the script from your terminal, specifying your search query, the number of images to fetch (`--n`), and the `--download` flag to save them locally. Downloaded images are saved by default to the `./images/` directory from your current working directory, organized into subfolders based on the search query.
 
     **Important**: Be mindful of Flickr's API rate limits and terms of service. Excessive requests may lead to temporary or permanent blocking. Refer to the official [Flickr API documentation](https://www.flickr.com/services/developer/api/) for detailed usage guidelines.
 
@@ -80,7 +80,7 @@ You should see output indicating the download progress:
 ...
 10/10 downloaded
 Done. (4.1s)
-All images saved to /Users/glennjocher/PycharmProjects/flickr_scraper/images/honeybees_on_flowers/
+All images saved to .../images/honeybees_on_flowers/
 ```
 
 The downloaded images will be available in the specified folder (e.g., `images/honeybees_on_flowers/`), ready for annotation, further processing, or direct use in training your models.
@@ -115,7 +115,7 @@ If the Flickr Scraper tool helps your research or work, please consider citing i
 
 Contributions are welcome! We value input from the community to fix bugs, add features, or improve documentation. Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing/) for details on how to get started. Don't forget to share your experiences and feedback by completing our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). Thank you 🙏 to all our contributors!
 
-[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/flickr_scraper/graphs/contributors)
 
 ## ©️ License
 


### PR DESCRIPTION
## Summary
- clarifies that downloads are saved under ./images from the current working directory
- replaces a local-machine sample output path with a generic path
- retargets the contributors link to this repository

## Validation
- git diff --check
- codespell README.md
- lychee README.md
- python -m compileall -q .
- pytest -q

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small but helpful README fixes by clarifying where downloaded images are saved and correcting the contributors link to point to the right repository.

### 📊 Key Changes
- 📁 Updated the usage instructions to explain that downloaded images are saved to the `./images/` folder in the user’s current working directory, not a fixed `flickr_scraper/images/` path.
- 🖼️ Simplified the example output path from a user-specific absolute path to a generic `.../images/honeybees_on_flowers/` example.
- 🔗 Fixed the contributors badge link so it now points to the `ultralytics/flickr_scraper` contributors page instead of the main `ultralytics/ultralytics` repository.

### 🎯 Purpose & Impact
- ✅ Reduces confusion for users by making the image download location clearer and more accurate.
- 🚀 Improves the onboarding experience, especially for new users following the README step by step.
- 🧭 Makes documentation more portable since the example no longer depends on one developer’s local file path.
- 🙌 Ensures contributor attribution links send users to the correct project, improving transparency and repository navigation.