### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub CI workflow to use `actions/checkout@v7` instead of `actions/checkout@v6`.

### 📊 Key Changes
- Upgraded the **GitHub Actions checkout step** in `.github/workflows/ci.yml`
- Replaced `actions/checkout@v6` with `actions/checkout@v7`
- No application code or scraper functionality was changed

### 🎯 Purpose & Impact
- Improves **CI maintenance** by keeping the workflow aligned with the latest GitHub Action version 🛠️
- May provide **bug fixes, performance improvements, or compatibility updates** from the newer checkout action
- Has **no direct impact on end users** of the scraper, but helps keep automated testing and repository workflows reliable ✅